### PR TITLE
Feature/add stream supported

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,8 +54,9 @@ new Command()
       .group("Search options")
       .option("--all", "Search all changesets (alpha/beta included)")
       .option("--pre-release, --beta", "Search only pre-release (alpha/beta) changesets", { conflicts: ["all", "lts", "xlts"] })
-      .option("--lts", "Only the LTS versions", { conflicts: ["all", "pre-release", "xlts"] })
-      .option("--xlts", "Only the LTS/XLTS versions (require 'Enterprise' or 'Industry' license to install XLTS version)", { conflicts: ["all", "pre-release", "lts"] })
+      .option("--lts", "Only the LTS versions", { conflicts: ["all", "pre-release", "xlts", "supported"] })
+      .option("--xlts", "Only the LTS/XLTS versions (require 'Enterprise' or 'Industry' license to install XLTS version)", { conflicts: ["all", "pre-release", "lts", "supported"] })
+      .option("--supported", "Only the supported versions (including Unity 6000)", { conflicts: ["all", "pre-release", "lts", "xlts"] })
       // Filter options.
       .group("Filter options")
       .option("--min <version>", "Minimum version (included)")
@@ -83,7 +84,9 @@ new Command()
               ? SearchMode.LTS
               : options.xlts
                 ? SearchMode.XLTS
-                : SearchMode.Default;
+                : options.supported
+                  ? SearchMode.SUPPORTED
+                  : SearchMode.Default;
 
         // Group mode.
         const groupMode = (options.latestPatch || options.minorVersionOnly)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { UnityChangeset as UnityChangesetClass } from "./unityChangeset.ts";
-import { getUnityReleases, getUnityReleasesInLTS, UnityReleaseEntitlement, UnityReleaseStream } from "./unityGraphQL.ts";
+import {
+  getUnityReleases,
+  getUnityReleasesInLTS,
+  UnityReleaseEntitlement,
+  UnityReleaseStream,
+} from "./unityGraphQL.ts";
 
 export const UnityChangeset = UnityChangesetClass;
 export type UnityChangeset = UnityChangesetClass;
@@ -12,8 +17,9 @@ export type UnityChangeset = UnityChangesetClass;
 export async function getUnityChangeset(
   version: string,
 ): Promise<UnityChangeset> {
-  const changesets = (await getUnityReleases(version, []))
-    .filter((c) => c.version === version);
+  const changesets = (await getUnityReleases(version, [])).filter(
+    (c) => c.version === version,
+  );
   if (0 < changesets.length) {
     return changesets[0];
   }
@@ -34,6 +40,7 @@ export enum SearchMode {
   PreRelease = 3,
   LTS = 4,
   XLTS = 5,
+  SUPPORTED = 6,
 }
 
 /*
@@ -144,6 +151,7 @@ export function searchChangesets(
     case SearchMode.All:
       return getUnityReleases(".", [
         UnityReleaseStream.LTS,
+        UnityReleaseStream.SUPPORTED,
         UnityReleaseStream.TECH,
         UnityReleaseStream.BETA,
         UnityReleaseStream.ALPHA,
@@ -151,6 +159,7 @@ export function searchChangesets(
     case SearchMode.Default:
       return getUnityReleases(".", [
         UnityReleaseStream.LTS,
+        UnityReleaseStream.SUPPORTED,
         UnityReleaseStream.TECH,
       ]);
     case SearchMode.PreRelease:
@@ -162,6 +171,8 @@ export function searchChangesets(
       return getUnityReleasesInLTS();
     case SearchMode.XLTS:
       return getUnityReleasesInLTS([UnityReleaseEntitlement.XLTS]);
+    case SearchMode.SUPPORTED:
+      return getUnityReleases(".", [UnityReleaseStream.SUPPORTED]);
     default:
       throw Error(`The given search mode '${searchMode}' was not supported`);
   }
@@ -186,17 +197,16 @@ export function filterChangesets(
   // Lifecycle filter
   const lc = options.allLifecycles
     ? null
-    : Object.values(groupBy(changesets, (r) => r.minor))
-      .map((g) => g[0]);
+    : Object.values(groupBy(changesets, (r) => r.minor)).map((g) => g[0]);
 
-  return changesets
-    .filter((c) =>
+  return changesets.filter(
+    (c) =>
       min <= c.versionNumber &&
       c.versionNumber <= max &&
       (!options.lts || c.lts) &&
       (!regex || regex.test(c.version)) &&
-      (!lc || lc.some((l) => l.minor == c.minor && l.lifecycle == c.lifecycle))
-    );
+      (!lc || lc.some((l) => l.minor == c.minor && l.lifecycle == c.lifecycle)),
+  );
 }
 
 export function groupChangesets(
@@ -213,8 +223,9 @@ export function groupChangesets(
         .map((g) => g.filter((v) => v.lifecycle == g[0].lifecycle))
         .flat();
     case GroupMode.LatestPatch:
-      return Object.values(groupBy(changesets, (r) => r.minor))
-        .map((g) => g[0]);
+      return Object.values(groupBy(changesets, (r) => r.minor)).map(
+        (g) => g[0],
+      );
     case GroupMode.OldestPatch:
       return Object.values(groupBy(changesets, (r) => r.minor))
         .map((g) => g.filter((v) => v.lifecycle == g[0].lifecycle))

--- a/src/unityChangeset.test.ts
+++ b/src/unityChangeset.test.ts
@@ -29,6 +29,7 @@ Deno.test("UnityChangeset.toNumber max", () => {
   { version: "2018.3.0f3", expected: undefined },
   { version: "2019.1.0a9", expected: "0acd256790e8" },
   { version: "2019.1.0b1", expected: "83b3ba1f99df" },
+  { version: "6000.1.0f1", expected: "9ea152932a88" },
 ].forEach((testcase) => {
   Deno.test(`getUnityChangeset (${testcase.version})`, async () => {
     if (testcase.expected) {
@@ -52,11 +53,22 @@ Deno.test("scrapeBetaChangesets", async () => {
   assertNotEquals(changesets.length, 0);
 });
 
+// At least one changeset from unity 6000 version should be found.
+Deno.test("scrapeUnity6000Supported", async () => {
+  const changesets = await searchChangesets(SearchMode.SUPPORTED);
+  console.log(changesets.map((c) => c.version));
+  assertNotEquals(changesets.length, 0);
+  
+  const unity6000 = changesets.find(c => c.version.startsWith("6000"));
+  assertNotEquals(unity6000, undefined);
+});
+
 // searchChangesets
 [
   { searchMode: SearchMode.All },
   { searchMode: SearchMode.Default },
   { searchMode: SearchMode.PreRelease },
+  { searchMode: SearchMode.SUPPORTED },
 ].forEach((testcase) => {
   Deno.test(`filterChangesets(${JSON.stringify(testcase.searchMode)})`, async () => {
     const changesets = await searchChangesets(testcase.searchMode);

--- a/src/unityGraphQL.ts
+++ b/src/unityGraphQL.ts
@@ -4,6 +4,7 @@ import { gql, GraphQLClient } from "npm:graphql-request@6.1.0";
 const UNITY_GRAPHQL_ENDPOINT: string = "https://services.unity.com/graphql";
 
 export enum UnityReleaseStream {
+  SUPPORTED = "SUPPORTED",
   LTS = "LTS",
   TECH = "TECH",
   BETA = "BETA",


### PR DESCRIPTION
# Add Supported for Unity 6000 Versions

_branch name has a typo in `steam` should be  `stream`_

## Summary

  This PR adds support for listing Unity 6000 supported versions by implementing       
  the SUPPORTED search mode functionality. It includes:

  - Implementation of SearchMode.SUPPORTED in the searchChangesets
  function
  - Addition of the --supported CLI option to filter for supported Unity     
   versions
  - New test case to verify Unity 6000 version detection
  - Updates to make UnityReleaseStream.SUPPORTED available in search
  results

 ## Changes

  1. Enhanced the searchChangesets function in index.ts to properly
  handle the SearchMode.SUPPORTED enum value
  2. Added the --supported CLI command-line option in cli.ts with
  appropriate conflict configurations
  3. Updated the default search mode in SearchMode.All to include the        
  SUPPORTED stream
  4. Created a dedicated test case in unityChangeset.test.ts to verify       
  Unity 6000 versions are properly detected
  5. Added Unity 6000 versions to the general test suite to ensure
  compatibility

  Testing

  - Verified that the --supported CLI option correctly returns Unity
  6000 versions
  - Confirmed test cases pass for the new functionality
  - Manually tested that Unity 6000 versions can be queried and display      
  properly in all output formats (plain text, JSON)

  This implementation addresses the need to work with the newer Unity        
  6000 releases.